### PR TITLE
coding etiquette 3: change the function parameter name

### DIFF
--- a/hw08/hw08.ipynb
+++ b/hw08/hw08.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "03db0738",
+   "id": "7324ed4b",
    "metadata": {},
    "source": [
     "# Homework 08\n",
@@ -138,29 +138,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 22,
    "id": "1c04f01c",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Get the information on 2018-01-01\n",
     "sr = requests.get('https://collectionapi.metmuseum.org/public/collection/v1/objects'\n",
     ", params = {'metadataDate': '2018-01-01'})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 25,
    "id": "1b77c2a8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "json_sr = sr.json()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "eca8bae2",
    "metadata": {},
    "outputs": [
     {
@@ -169,29 +160,21 @@
        "dict_keys(['total', 'objectIDs'])"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "# show the keys of the json result\n",
+    "json_sr = sr.json()\n",
     "json_sr.keys()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 23,
    "id": "ad708064",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "count = json_sr['total']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "962771b7",
    "metadata": {},
    "outputs": [
     {
@@ -200,29 +183,21 @@
        "477921"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "count #printing total count of Object IDs"
+    "# find out the total count of Object IDs\n",
+    "count = json_sr['total']\n",
+    "count "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 24,
    "id": "252152de",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ids = json_sr['objectIDs']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "349ff83e",
    "metadata": {},
    "outputs": [
     {
@@ -234,7 +209,9 @@
     }
    ],
    "source": [
-    "print(ids[:10]) #printing list of Object IDs"
+    "# show the list of first ten Object IDs\n",
+    "ids = json_sr['objectIDs']\n",
+    "print(ids[:10])"
    ]
   },
   {
@@ -318,6 +295,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Put the request results for Object IDs into a dataframe\n",
     "response_dict = pd.DataFrame.from_dict(json_sr)"
    ]
   },
@@ -341,7 +319,8 @@
     }
    ],
    "source": [
-    "print(response_dict.head()) #The above request for Object IDs as a dataframe"
+    "# Show the first five rows to give the read a sense of how this dataframe looks like\n",
+    "print(response_dict.head())"
    ]
   },
   {
@@ -359,6 +338,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Make a new request to search information about French artists and culture\n",
     "req = requests.get('https://collectionapi.metmuseum.org/public/collection/v1/search?artistOrCulture=true&q=french')"
    ]
   },
@@ -400,6 +380,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# A dataframe listing objectIDs where the artist or culture is \n",
     "api_dataset = pd.DataFrame.from_dict(req_json)"
    ]
   },
@@ -423,7 +404,7 @@
     }
    ],
    "source": [
-    "print(api_dataset.head()) #a dataframe listing objectIDs where the artist or culture is \n",
+    "print(api_dataset.head()) \n",
     "#French, with 15230 total records"
    ]
   },
@@ -463,14 +444,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 27,
    "id": "c4bc2e2c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def run_a_get(par = '2018-01-01'):\n",
+    "def run_a_get(date):\n",
     "    sr = requests.get('https://collectionapi.metmuseum.org/public/collection/v1/objects'\n",
-    ", params = {'metadataDate': par})\n",
+    ", params = {'metadataDate': date})\n",
     "    return sr.status_code \n",
     "    return sr.headers.get('content-type')\n",
     "    json_sr = sr.json()\n",
@@ -481,7 +462,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 29,
    "id": "2e139f73",
    "metadata": {},
    "outputs": [
@@ -491,27 +472,19 @@
        "200"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "run_a_get()"
+    "run_a_get(date = '2018-01-01')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "395cd6b3",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "19a6952d",
+   "id": "4b79890c",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
It is better to use a meaningful parameter name such as date, instead of simply use 'par'.