### PR TITLE
coding etiquette 4: change the function name

### DIFF
--- a/hw08/hw08.ipynb
+++ b/hw08/hw08.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "7324ed4b",
+   "id": "e62a86a1",
    "metadata": {},
    "source": [
     "# Homework 08\n",
@@ -449,7 +449,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def run_a_get(date):\n",
+    "def met_collections(date):\n",
     "    sr = requests.get('https://collectionapi.metmuseum.org/public/collection/v1/objects'\n",
     ", params = {'metadataDate': date})\n",
     "    return sr.status_code \n",
@@ -484,7 +484,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b79890c",
+   "id": "7c2df040",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Meaningful function names can help users better understand what this function is doing. So I recommend you to use met_collection rather than get_a_request.