### PR TITLE
coding etiquette 6: further change comments

### DIFF
--- a/hw08/hw08.ipynb
+++ b/hw08/hw08.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "07c9773b",
+   "id": "62b8ccb1",
    "metadata": {},
    "source": [
     "# Homework 08\n",
@@ -404,8 +404,8 @@
     }
    ],
    "source": [
-    "print(api_dataset.head()) \n",
-    "#French, with 15230 total records"
+    "# French, with 27,413 total records as of March 21, 2022\n",
+    "print(api_dataset.head()) "
    ]
   },
   {
@@ -597,7 +597,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4569862f",
+   "id": "5ef637cf",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Since your API call doesn't specify the date, the total number may change every time you call the API, so you'd better specify the calling date in your comments so that users will not get confused.